### PR TITLE
Feature: mappable meta

### DIFF
--- a/Brick.xcodeproj/project.pbxproj
+++ b/Brick.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		BD6D7AE21CBA768A00FBF0BD /* Fakery.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD6D7AE11CBA768A00FBF0BD /* Fakery.framework */; };
 		BDDA5FEB1CBBCF45000FD5A6 /* ViewConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDA5FEA1CBBCF45000FD5A6 /* ViewConfigurable.swift */; };
 		BDDA5FEC1CBBCF45000FD5A6 /* ViewConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDA5FEA1CBBCF45000FD5A6 /* ViewConfigurable.swift */; };
+		D57832991CE142DE005ED144 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57832961CE142C8005ED144 /* Helpers.swift */; };
+		D578329A1CE142DF005ED144 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57832961CE142C8005ED144 /* Helpers.swift */; };
 		D5ACAC9A1CCE439F00567809 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5ACAC991CCE439F00567809 /* Extensions.swift */; };
 		D5ACAC9B1CCE439F00567809 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5ACAC991CCE439F00567809 /* Extensions.swift */; };
 		D5ACAC9F1CCE45CE00567809 /* ExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5ACAC9C1CCE449A00567809 /* ExtensionsSpec.swift */; };
@@ -60,6 +62,7 @@
 		BDDA5FEA1CBBCF45000FD5A6 /* ViewConfigurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewConfigurable.swift; sourceTree = "<group>"; };
 		D500FD111C3AABED00782D78 /* Playground-iOS.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Playground-iOS.playground"; sourceTree = "<group>"; };
 		D500FD121C3AAC8E00782D78 /* Playground-Mac.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Playground-Mac.playground"; sourceTree = "<group>"; };
+		D57832961CE142C8005ED144 /* Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		D5ACAC991CCE439F00567809 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		D5ACAC9C1CCE449A00567809 /* ExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionsSpec.swift; sourceTree = "<group>"; };
 		D5B2E89F1C3A780C00C0327D /* Brick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Brick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -206,6 +209,7 @@
 			children = (
 				D5C629971C3A8BDA007F7B7C /* VIewModelSpec.swift */,
 				D5ACAC9C1CCE449A00567809 /* ExtensionsSpec.swift */,
+				D57832961CE142C8005ED144 /* Helpers.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -482,6 +486,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D5ACAC9F1CCE45CE00567809 /* ExtensionsSpec.swift in Sources */,
+				D57832991CE142DE005ED144 /* Helpers.swift in Sources */,
 				D5C6299E1C3A8C75007F7B7C /* VIewModelSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -502,6 +507,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D5ACACA01CCE45CF00567809 /* ExtensionsSpec.swift in Sources */,
+				D578329A1CE142DF005ED144 /* Helpers.swift in Sources */,
 				D5C6299C1C3A8BDA007F7B7C /* VIewModelSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BrickTests/Shared/ExtensionsSpec.swift
+++ b/BrickTests/Shared/ExtensionsSpec.swift
@@ -51,5 +51,19 @@ class ExtensionsSpec: QuickSpec {
         }
       }
     }
+
+    describe("Mappable+Brick") {
+      let item = Meta(id: 11, name: "Name")
+
+      describe("#metaDictionary") {
+        it("returns an array of properties") {
+          var dictionary = ["id": 11, "name": "Name"]
+          var result = item.metaProperties
+
+          expect(result["id"] as? Int).to(equal(dictionary["id"]))
+          expect(result["name"] as? String).to(equal(dictionary["name"]))
+        }
+      }
+    }
   }
 }

--- a/BrickTests/Shared/Helpers.swift
+++ b/BrickTests/Shared/Helpers.swift
@@ -3,7 +3,7 @@ import Sugar
 
 struct Meta: Mappable {
   var id = 0
-  var name: String? = ""
+  var name: String?
 
   init(_ map: JSONDictionary) {
     id <- map.property("id")

--- a/BrickTests/Shared/Helpers.swift
+++ b/BrickTests/Shared/Helpers.swift
@@ -1,0 +1,12 @@
+import Tailor
+import Sugar
+
+struct Meta: Mappable {
+  var id = 0
+  var name = ""
+
+  init(_ map: JSONDictionary) {
+    id <- map.property("id")
+    name <- map.property("name")
+  }
+}

--- a/BrickTests/Shared/Helpers.swift
+++ b/BrickTests/Shared/Helpers.swift
@@ -3,7 +3,7 @@ import Sugar
 
 struct Meta: Mappable {
   var id = 0
-  var name = ""
+  var name: String? = ""
 
   init(_ map: JSONDictionary) {
     id <- map.property("id")

--- a/BrickTests/Shared/Helpers.swift
+++ b/BrickTests/Shared/Helpers.swift
@@ -3,7 +3,7 @@ import Sugar
 
 struct Meta {
   var id = 0
-  var name: String? = ""
+  var name: String?
 }
 
 extension Meta: Mappable {

--- a/BrickTests/Shared/Helpers.swift
+++ b/BrickTests/Shared/Helpers.swift
@@ -1,9 +1,12 @@
 import Tailor
 import Sugar
 
-struct Meta: Mappable {
+struct Meta {
   var id = 0
-  var name: String?
+  var name: String? = ""
+}
+
+extension Meta: Mappable {
 
   init(_ map: JSONDictionary) {
     id <- map.property("id")

--- a/BrickTests/Shared/VIewModelSpec.swift
+++ b/BrickTests/Shared/VIewModelSpec.swift
@@ -78,6 +78,17 @@ class ViewModelSpec: QuickSpec {
         }
       }
 
+      describe("#metaInstance") {
+        it("resolves meta data created from object") {
+          var data = ["id": 11, "name": "Name"]
+          viewModel = ViewModel(meta: Meta(data))
+          let result: Meta = viewModel.metaInstance()
+
+          expect(result.id).to(equal(data["id"]))
+          expect(result.name).to(equal(data["name"]))
+        }
+      }
+
       describe("#dictionary") {
         beforeEach {
           data["relations"] = ["viewmodels" : [data, data]]

--- a/BrickTests/Shared/VIewModelSpec.swift
+++ b/BrickTests/Shared/VIewModelSpec.swift
@@ -64,12 +64,17 @@ class ViewModelSpec: QuickSpec {
       }
 
       describe("#meta") {
-        beforeEach {
+        it("resolves meta data created from JSON") {
           viewModel = ViewModel(data)
+          expect(viewModel.meta("domain", "")).to(equal(data["meta"]!["domain"]))
         }
 
-        it("resolves meta data") {
-          expect(viewModel.meta("domain", "")).to(equal(data["meta"]!["domain"]))
+        it("resolves meta data created from object") {
+          var data = ["id": 11, "name": "Name"]
+
+          viewModel = ViewModel(meta: Meta(data))
+          expect(viewModel.meta("id", 0)).to(equal(data["id"]))
+          expect(viewModel.meta("name", "")).to(equal(data["name"]))
         }
       }
 

--- a/Sources/Shared/Extensions.swift
+++ b/Sources/Shared/Extensions.swift
@@ -1,3 +1,5 @@
+import Tailor
+
 // MARK: - Array
 
 public extension _ArrayType where Generator.Element == ViewModel {
@@ -39,5 +41,31 @@ extension Dictionary where Key: StringLiteralConvertible {
       guard let key = key.string as? Key else { return nil }
       return self[key]
     }
+  }
+}
+
+// MARK: - Mappable
+
+extension Mappable {
+
+  /**
+   - Returns: A key-value dictionary.
+   */
+  var metaProperties: [String : AnyObject] {
+    var properties = [String : AnyObject]()
+
+    for tuple in Mirror(reflecting: self).children {
+      guard let key = tuple.label else { continue }
+
+      if let value = tuple.value as? AnyObject {
+        properties[key] = value
+      } else if let value = Mirror(reflecting: tuple.value).descendant("Some") as? AnyObject {
+        properties[key] = value
+      } else {
+        continue
+      }
+    }
+
+    return properties
   }
 }

--- a/Sources/Shared/ViewModel.swift
+++ b/Sources/Shared/ViewModel.swift
@@ -149,8 +149,13 @@ public struct ViewModel: Mappable {
     var metaDictionary = JSONDictionary()
 
     for (key, item) in meta.properties() {
-      guard let value = item as? AnyObject else { continue }
-      metaDictionary[key] = value
+      if let value = item as? AnyObject {
+        metaDictionary[key] = value
+      } else if let value = Mirror(reflecting: item).descendant("Some") as? AnyObject {
+        metaDictionary[key] = value
+      } else {
+        continue
+      }
     }
 
     self.init(title: title, subtitle: subtitle, image: image, kind: kind, action: action,

--- a/Sources/Shared/ViewModel.swift
+++ b/Sources/Shared/ViewModel.swift
@@ -146,20 +146,8 @@ public struct ViewModel: Mappable {
    - Parameter image: Image name or URL as a string, default to empty string
    */
   public init(title: String = "", subtitle: String = "", image: String = "", kind: StringConvertible = "", action: String? = nil, size: CGSize = CGSize(width: 0, height: 0), meta: Mappable, relations: [String : [ViewModel]] = [:]) {
-    var metaDictionary = JSONDictionary()
-
-    for (key, item) in meta.properties() {
-      if let value = item as? AnyObject {
-        metaDictionary[key] = value
-      } else if let value = Mirror(reflecting: item).descendant("Some") as? AnyObject {
-        metaDictionary[key] = value
-      } else {
-        continue
-      }
-    }
-
     self.init(title: title, subtitle: subtitle, image: image, kind: kind, action: action,
-              size: size, meta: metaDictionary, relations: relations)
+              size: size, meta: meta.metaProperties, relations: relations)
   }
 
   // MARK: - Helpers

--- a/Sources/Shared/ViewModel.swift
+++ b/Sources/Shared/ViewModel.swift
@@ -138,6 +138,25 @@ public struct ViewModel: Mappable {
     self.relations = relations
   }
 
+  /**
+   Initialization a new instance of a ViewModel and map it to a JSON dictionary
+
+   - Parameter title: The title string for the view model, defaults to empty string
+   - Parameter subtitle: The subtitle string for the view model, default to empty string
+   - Parameter image: Image name or URL as a string, default to empty string
+   */
+  public init(title: String = "", subtitle: String = "", image: String = "", kind: StringConvertible = "", action: String? = nil, size: CGSize = CGSize(width: 0, height: 0), meta: Mappable, relations: [String : [ViewModel]] = [:]) {
+    var metaDictionary = JSONDictionary()
+
+    for (key, item) in meta.properties() {
+      guard let value = item as? AnyObject else { continue }
+      metaDictionary[key] = value
+    }
+
+    self.init(title: title, subtitle: subtitle, image: image, kind: kind, action: action,
+              size: size, meta: metaDictionary, relations: relations)
+  }
+
   // MARK: - Helpers
 
   /**

--- a/Sources/Shared/ViewModel.swift
+++ b/Sources/Shared/ViewModel.swift
@@ -162,6 +162,10 @@ public struct ViewModel: Mappable {
     return meta[key] as? T
   }
 
+  public func metaInstance<T: Mappable>() -> T {
+    return T(meta)
+  }
+
   /**
    A convenience lookup method for resolving view model relations
 

--- a/Sources/Shared/ViewModel.swift
+++ b/Sources/Shared/ViewModel.swift
@@ -181,6 +181,11 @@ public struct ViewModel: Mappable {
     return meta[key] as? T
   }
 
+  /**
+   A generic convenience method for resolving meta instance
+
+   - Returns: A generic meta instance based on `type`
+   */
   public func metaInstance<T: Mappable>() -> T {
     return T(meta)
   }


### PR DESCRIPTION
@zenangst 
Got a new idea regarding our discussions about meta. So instead of using enums or magic generators we can use Mappable structs 😄 

``` swift
struct ProductMeta {
  var id = 0
  var name: String?
}

extension ProductMeta: Mappable {
  init(_ map: JSONDictionary) {
    id <- map.property("id")
    name <- map.property("name")
  }
}

let productMeta = ProductMeta(id: 11, name: "Name")
let viewModel = ViewModel(title: "Title", meta: productMeta)
// ...
let meta: ProductMeta = viewModel.metaInstance()
print(meta.id) // => 11
```

My only concern is than it might be too much code, because you have to implement mapping, don't see any way to avoid this, even though property key always reflects the property name. But with this approach you write string only once which is nice.
