### PR TITLE
Fix/mapping size

### DIFF
--- a/BrickTests/Shared/ItemSpec.swift
+++ b/BrickTests/Shared/ItemSpec.swift
@@ -18,6 +18,7 @@ class ItemSpec: QuickSpec {
           "text": faker.lorem.paragraph(),
           "image" : faker.internet.image(),
           "kind" : faker.team.name(),
+          "size" : ["width" : 320.0, "height" : 240.0],
           "action" : faker.internet.ipV6Address(),
           "meta" : [
             "domain" : faker.internet.domainName()
@@ -41,6 +42,8 @@ class ItemSpec: QuickSpec {
           expect(item.image).to(equal(data["image"] as? String))
           expect(item.kind).to(equal(data["kind"] as? String))
           expect(item.action).to(equal(data["action"] as? String))
+          expect(item.size.width).to(equal(CGFloat(320.0)))
+          expect(item.size.height).to(equal(CGFloat(240.0)))
           expect(item.meta("domain", "")).to(equal(((data["meta"] as! [String : AnyObject])["domain"] as? String)))
         }
       }

--- a/Sources/Shared/Item.swift
+++ b/Sources/Shared/Item.swift
@@ -134,10 +134,9 @@ public struct Item: Mappable, Indexable {
       }
     }
 
-    size = CGSize(
-      width:  ((map[.Size] as? [String : Any])?[.Width] as? Int) ?? 0,
-      height: ((map[.Size] as? [String : Any])?[.Height] as? Int) ?? 0
-    )
+    let width: Double = map.resolve(keyPath: "size.width") ?? 0.0
+    let height: Double = map.resolve(keyPath: "size.height") ?? 0.0
+    size = CGSize(width: width, height: height)
   }
 
   /**


### PR DESCRIPTION
We had a minor bug in the init method that maps `size` to `Item`.
This was caused by type-casting that worked in earlier versions of Swift but it no longer supported.

What we do to fix this issue is to resolve the value as a `Double` and the create a `CGSize` using both `width` and `height` from the JSON payload.

Improved the tests to take `size` into account when testing the `Item`.
