### PR TITLE
Check if there are any children when before creating the key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ osx_image: xcode8
 language: objective-c
 
 before_install:
-- brew update
-- if brew outdated | grep -qx carthage; then brew upgrade carthage; fi
 - travis_wait 35 carthage bootstrap --platform iOS,Mac,tvOS
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ before_install:
 - travis_wait 35 carthage bootstrap --platform iOS,Mac,tvOS
 
 script:
-- xcodebuild clean build -project Brick.xcodeproj -scheme Brick-iOS -sdk iphonesimulator
-- xcodebuild test -project Brick.xcodeproj -scheme Brick-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0'
-- xcodebuild clean build -project Brick.xcodeproj -scheme Brick-Mac -sdk macosx
-- xcodebuild test -project Brick.xcodeproj -scheme Brick-Mac -sdk macosx
-- xcodebuild clean build -project Brick.xcodeproj -scheme "Brick-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0'
-- xcodebuild test -project Brick.xcodeproj -scheme "Brick-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0'
+- xcodebuild clean build -project Brick.xcodeproj -scheme Brick-iOS -sdk iphonesimulator | xcpretty
+- xcodebuild test -project Brick.xcodeproj -scheme Brick-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' | xcpretty
+- xcodebuild clean build -project Brick.xcodeproj -scheme Brick-Mac -sdk macosx | xcpretty
+- xcodebuild test -project Brick.xcodeproj -scheme Brick-Mac -sdk macosx | xcpretty
+- xcodebuild clean build -project Brick.xcodeproj -scheme "Brick-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' | xcpretty
+- xcodebuild test -project Brick.xcodeproj -scheme "Brick-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' | xcpretty
 
 notifications:
   email: false

--- a/Sources/Shared/Item.swift
+++ b/Sources/Shared/Item.swift
@@ -85,7 +85,9 @@ public struct Item: Mappable, Indexable {
       dictionary[Key.Action.string] = action
     }
 
-    dictionary[Key.Children.string] = children
+    if !children.isEmpty {
+      dictionary[Key.Children.string] = children
+    }
 
     var relationItems = [String : [[String : Any]]]()
 


### PR DESCRIPTION
This PR cleans up the dictionary representation of `Item`. The thing that it fixes is that it checks if there are any children before adding it to the dictionary. This will help clean up your JSON file as it won’t add empty keys for `children`.
