### PR TITLE
Improve/handling children

### DIFF
--- a/Brick.xcodeproj/project.pbxproj
+++ b/Brick.xcodeproj/project.pbxproj
@@ -220,12 +220,12 @@
 		D5C6296E1C3A809D007F7B7C /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				BDDB1A531E09AF7300DFF834 /* DictionaryConvertable.swift */,
+				D5ACAC991CCE439F00567809 /* Extensions.swift */,
+				BD80D9201DA2AACA00675D5F /* Indexable.swift */,
 				D5C629861C3A89A8007F7B7C /* Item.swift */,
 				BDDA5FEA1CBBCF45000FD5A6 /* ItemConfigurable.swift */,
 				DAA38AA41CBEEAD900D48603 /* StringConvertible.swift */,
-				D5ACAC991CCE439F00567809 /* Extensions.swift */,
-				BD80D9201DA2AACA00675D5F /* Indexable.swift */,
-				BDDB1A531E09AF7300DFF834 /* DictionaryConvertable.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";

--- a/Brick.xcodeproj/project.pbxproj
+++ b/Brick.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		BDBA5F221D940F09003A5C6B /* Brick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDFD54221D940EDC003CB98B /* Brick.framework */; };
 		BDDA5FEB1CBBCF45000FD5A6 /* ItemConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDA5FEA1CBBCF45000FD5A6 /* ItemConfigurable.swift */; };
 		BDDA5FEC1CBBCF45000FD5A6 /* ItemConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDA5FEA1CBBCF45000FD5A6 /* ItemConfigurable.swift */; };
+		BDDB1A541E09AF7300DFF834 /* DictionaryConvertable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDB1A531E09AF7300DFF834 /* DictionaryConvertable.swift */; };
 		BDE7D2171D940FC300027CE4 /* ItemSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C629971C3A8BDA007F7B7C /* ItemSpec.swift */; };
 		BDE7D2181D940FC300027CE4 /* ExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5ACAC9C1CCE449A00567809 /* ExtensionsSpec.swift */; };
 		BDE7D2191D940FC300027CE4 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57832961CE142C8005ED144 /* Helpers.swift */; };
@@ -85,6 +86,7 @@
 		BD80D9201DA2AACA00675D5F /* Indexable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Indexable.swift; sourceTree = "<group>"; };
 		BDBA5F1D1D940F09003A5C6B /* Brick-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Brick-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDDA5FEA1CBBCF45000FD5A6 /* ItemConfigurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ItemConfigurable.swift; sourceTree = "<group>"; };
+		BDDB1A531E09AF7300DFF834 /* DictionaryConvertable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryConvertable.swift; sourceTree = "<group>"; };
 		BDE7D2151D940F7800027CE4 /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
 		BDE7D2161D940FAA00027CE4 /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
 		BDFD54221D940EDC003CB98B /* Brick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Brick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -223,6 +225,7 @@
 				DAA38AA41CBEEAD900D48603 /* StringConvertible.swift */,
 				D5ACAC991CCE439F00567809 /* Extensions.swift */,
 				BD80D9201DA2AACA00675D5F /* Indexable.swift */,
+				BDDB1A531E09AF7300DFF834 /* DictionaryConvertable.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -647,6 +650,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D5C629871C3A89A8007F7B7C /* Item.swift in Sources */,
+				BDDB1A541E09AF7300DFF834 /* DictionaryConvertable.swift in Sources */,
 				D5ACAC9A1CCE439F00567809 /* Extensions.swift in Sources */,
 				BD80D9211DA2AACA00675D5F /* Indexable.swift in Sources */,
 				BDDA5FEB1CBBCF45000FD5A6 /* ItemConfigurable.swift in Sources */,

--- a/BrickTests/Shared/ItemSpec.swift
+++ b/BrickTests/Shared/ItemSpec.swift
@@ -20,6 +20,10 @@ class ItemSpec: QuickSpec {
           "kind" : faker.team.name(),
           "size" : ["width" : 320.0, "height" : 240.0],
           "action" : faker.internet.ipV6Address(),
+          "children" : [
+            "child 1" : "Anna",
+            "child 2" : "Elsa"
+          ],
           "meta" : [
             "domain" : faker.internet.domainName()
           ]
@@ -182,6 +186,23 @@ class ItemSpec: QuickSpec {
         it("updates kind") {
           item.update(kind: "test")
           expect(item.kind).to(equal("test"))
+        }
+      }
+
+      describe("#compareChildren") {
+        beforeEach {
+          item = Item(data)
+        }
+
+        it("compare children properly") {
+          let sameItem = Item(data)
+
+          var newData: [String : Any] = data!
+          newData["children"] = [["child 1" : "Anna"]]
+          let otherItem = Item(newData)
+
+          expect(item === sameItem).to(beTrue())
+          expect(item === otherItem).to(beFalse())
         }
       }
 

--- a/Sources/Shared/DictionaryConvertable.swift
+++ b/Sources/Shared/DictionaryConvertable.swift
@@ -1,0 +1,6 @@
+/**
+ A protocol for returning a dictionary representation of self
+ */
+public protocol DictionaryConvertible {
+  var dictionary: [String : Any] { get }
+}

--- a/Sources/Shared/Item.swift
+++ b/Sources/Shared/Item.swift
@@ -157,6 +157,7 @@ public struct Item: Mappable, Indexable {
               action: String? = nil,
               size: CGSize = CGSize(width: 0, height: 0),
               meta: [String : Any] = [:],
+              children: [DictionaryConvertible] = [],
               relations: [String : [Item]] = [:]) {
     self.identifier = identifier
     self.title = title
@@ -167,6 +168,7 @@ public struct Item: Mappable, Indexable {
     self.action = action
     self.size = size
     self.meta = meta
+    self.children = children.map { $0.dictionary }
     self.relations = relations
   }
 

--- a/Sources/Shared/Item.swift
+++ b/Sources/Shared/Item.swift
@@ -335,6 +335,7 @@ public func ===(lhs: Item, rhs: Item) -> Bool {
     lhs.kind == rhs.kind &&
     lhs.action == rhs.action &&
     lhs.size == rhs.size &&
+    (lhs.children as NSArray).isEqual(to: rhs.children) &&
     (lhs.meta as NSDictionary).isEqual(to: rhs.meta) &&
     compareRelations(lhs, rhs)
 

--- a/Sources/Shared/Item.swift
+++ b/Sources/Shared/Item.swift
@@ -9,7 +9,7 @@ import Tailor
 /**
  A value type struct, it conforms to the Mappable protocol so that it can be instantiated with JSON
  */
-public struct Item: Mappable, Indexable {
+public struct Item: Mappable, Indexable, DictionaryConvertible {
 
   /**
    An enum with all the string keys used in the view model


### PR DESCRIPTION
This PR improves working with the `children` property on `Item`.

It is now included when comparing `Item`'s using `===`.

The property is now also available in the initializer.

When working with custom structs, you can implement the new `DictionaryConvertable` to make it easier to add them as children to an `Item`.